### PR TITLE
example: what new block interface looks like

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ provided raw bytes of a block (`block`) and store it with the associated CID.
   * **`options.blockCodec`** _(`string`, optional, default=`'dag-json'`)_: The IPLD codec used to encode the blocks.
   * **`options.blockAlg`** _(`string`, optional, default=`'sha2-256'`)_: The hash algorithm to use when creating CIDs for
     the blocks.
-  * **`options.hashAlg`** _(`string`, optional, default=`'murmur3-32'`)_: The hash algorithm used for indexing this
+  * **`options.hamtAlg`** _(`string`, optional, default=`'murmur3-32'`)_: The hash algorithm used for indexing this
     HashMap. `'murmur3-32'` is the x86 32-bit Murmur3 hash algorithm, used by default. If you want
     to change this default, you need to provide a new algorithm. For custom hash algorithms,
-    `hashAlg`, `hasher` and `hashBytes` must be provided together.
-  * **`options.hasher`** _(`function`, optional, default=`murmur3.x86`)_: A function that takes a byte array
+    `hamtAlg`, `hamtHasher` and `hashBytes` must be provided together.
+  * **`options.hamtHasher`** _(`function`, optional, default=`murmur3.x86`)_: A function that takes a byte array
     (`Uint8Array`) and should return a byte representing a hash of the input. Supply this option if
     you wish to override the default `'murmur3-32'` hasher.
   * **`options.hashBytes`** _(`number`, optional, default=`32`)_: The number of bytes to expect from `hasher` function.

--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,18 @@
+const codec = require('@ipld/dag-cbor')
+const hasher = require('multiformats/hashes/sha2').sha256
+const { create } = require('./ipld-hashmap.js')
+
+const defaults = { codec, hasher }
+
+module.exports.create = ({loader, root, options}) => {
+  if (!options) options = {}
+  if (!loader || typeof loader.get !== 'function' || typeof loader.put !== 'function') {
+    throw new TypeError('HashMap.create() requires a loader object with get() and put() methods')
+  }
+
+  if (options && typeof options !== 'object') {
+    throw new TypeError('HashMap.create() the \'options\' argument must be an object')
+  }
+
+  return create(loader, root, { ...defaults, ...options })
+}

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ipld/block": "~2.0.4",
-    "cids": "~0.7.1",
-    "iamap": "~0.6.0",
+    "@ipld/dag-cbor": "^2.0.2",
+    "iamap": "~0.7.0",
+    "multiformats": "^4.1.0",
     "murmurhash3js-revisited": "~3.0.0"
   },
   "devDependencies": {
     "jsdoc4readme": "~1.3.0",
-    "multihashing-async": "~0.7.0",
-    "tap": "~14.6.1"
+    "multihashing-async": "~2.0.1",
+    "tap": "~14.10.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Don’t merge this.

There are a fair number of issues getting this on our new stack.

* `tap` appears to be hijacking the module system and can’t support `exports` in package.json, so that’s gonna have to get factored out.
* it’s not ideal to ship dag-cbor to every consumer, even when they use a different codec. i have split the default codec stuff into another file but in order for that to work cleanly with the options system there are other API changes you may not want.
* the version of iamap this was using had some dep issues and i’m not sure there weren’t other API changes that might break this library with the upgrade it’ll force.

I’ve got a util library on top of `iamap` that I’m going to work on migrating next and that will probably go a little smoother. It’s hard to reconcile a lot of the default option setting this library does with the more modular approach we have now because these defaults all mean that you end up including everything in your bundle even when you don’t use it.

But, I did enough that you can see how the new inteface differs from the old, so I figured I should send it your way as an example.